### PR TITLE
Feature/linux common

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,19 @@
 cmake_minimum_required(VERSION 3.20)
 
-set(CMAKE_CXX_STANDARD 23)
-
 PROJECT(OpenCloud)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native") # Enable SSE/AVX
+
+add_library(ProjectConfiguration INTERFACE)
+
+# global include directories
+target_include_directories(ProjectConfiguration INTERFACE  "${PROJECT_SOURCE_DIR}/code")
+
+# global features
+target_compile_features(ProjectConfiguration INTERFACE cxx_std_23)
+
+IF ((CMAKE_CXX_COMPILER_ID STREQUAL "Clang") OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=x86-64-v2 -mavx -mfma") # Enable SSE/AVX
+ENDIF()
 add_subdirectory("external/fmt")
 add_subdirectory("code")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.20)
+
+set(CMAKE_CXX_STANDARD 23)
+
+PROJECT(OpenCloud)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native") # Enable SSE/AVX
+add_subdirectory("external/fmt")
+add_subdirectory("code")
+
+# Notes
+# sudo apt install g++-10 : C++20 headers
+# sudo ./cmake-3.25.1-linux-x86_64.sh --skip-license --exclude-subdir --prefix=/usr : install cmake from release script

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.20)
+
+set(CMAKE_CXX_STANDARD 23)
+
+######################
+# BUILD DEPENDENCIES #
+######################
+add_subdirectory("common")
+#add_subdirectory("script")
+#add_subdirectory("graph")
+#add_subdirectory("host")
+#add_subdirectory("dc2")
+
+##############################
+# BUILD OPENCLOUD EXECUTABLE #
+##############################
+# Enable and IF-guard when host is ported
+#SET(
+#    SOURCES
+#    "host/linuxmain.cc"
+#)
+
+#PROJECT(OpenCloudExe)
+#add_executable(${PROJECT_NAME} ${SOURCES})
+
+#find_package(X11 REQUIRED)
+#target_link_libraries(${PROJECT_NAME} PRIVATE ${X11_LIBRARIES})
+#target_include_directories(${PROJECT_NAME} PRIVATE ${X11_INCLUDE_DIR})
+
+#find_package(OpenGL REQUIRED)
+#target_link_libraries(${PROJECT_NAME} PRIVATE OpenGL::OpenGL OpenGL::GLX OpenGL::GLU)
+#target_include_directories(${PROJECT_NAME} PRIVATE ${OPENGL_INCLUDE_DIR})
+
+# Puts the names of non-static functions into the link tables so the generated backtrace
+# is actually readable
+#IF (CMAKE_BUILD_TYPE MATCHES Debug)
+#    IF (("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang") OR ("${CMAKE_CXX_COMPILER_ID}" #STREQUAL "GNU"))
+#        target_link_options(${PROJECT_NAME} PRIVATE "-rdynamic")
+#    ENDIF()
+#ENDIF()

--- a/code/common/CMakeLists.txt
+++ b/code/common/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required(VERSION 3.20)
 
-set(CMAKE_CXX_STANDARD 23)
-
 project(OpenCloudCommon)
 
-set(
-    SOURCES
+add_library(${PROJECT_NAME} STATIC)
+target_sources(
+    ${PROJECT_NAME}
+    PRIVATE
     "clock.cc"
     "console_logger.cc"
     "console.cc"
@@ -16,10 +16,7 @@ set(
     "log.cc"
     "strings.cc"
     "synchro.cc"
-)
-
-set(
-    HEADERS
+    
     "aligned_allocator.h"
     "bits.h"
     "clock.h"
@@ -42,9 +39,7 @@ set(
     "window_handle.h"
 )
 
-add_library(${PROJECT_NAME} STATIC ${SOURCES} ${HEADERS})
-target_include_directories (${PROJECT_NAME} PUBLIC ..) # So that the folder name can be used in imports
-target_link_libraries(${PROJECT_NAME} PRIVATE fmt::fmt)
+target_link_libraries(${PROJECT_NAME} PRIVATE ProjectConfiguration PUBLIC fmt::fmt)
 
 # Include pthread for Linux
 IF (UNIX)

--- a/code/common/CMakeLists.txt
+++ b/code/common/CMakeLists.txt
@@ -1,0 +1,54 @@
+cmake_minimum_required(VERSION 3.20)
+
+set(CMAKE_CXX_STANDARD 23)
+
+project(OpenCloudCommon)
+
+set(
+    SOURCES
+    "clock.cc"
+    "console_logger.cc"
+    "console.cc"
+    "data_stream.cc"
+    "debug.cc"
+    "dynamic_library.cc"
+    "file_helpers.cc"
+    "log.cc"
+    "strings.cc"
+    "synchro.cc"
+)
+
+set(
+    HEADERS
+    "aligned_allocator.h"
+    "bits.h"
+    "clock.h"
+    "console_logger.h"
+    "console.h"
+    "constants.h"
+    "data_stream.h"
+    "debug.h"
+    "dynamic_library.h"
+    "file_helpers.h"
+    "helpers.h"
+    "log.h"
+    "macros.h"
+    "math.h"
+    "platform.h"
+    "scoped_function.h"
+    "strings.h"
+    "synchro.h"
+    "types.h"
+    "window_handle.h"
+)
+
+add_library(${PROJECT_NAME} STATIC ${SOURCES} ${HEADERS})
+target_include_directories (${PROJECT_NAME} PUBLIC ..) # So that the folder name can be used in imports
+target_link_libraries(${PROJECT_NAME} PRIVATE fmt::fmt)
+
+# Include pthread for Linux
+IF (UNIX)
+    set(THREADS_PREFER_PTHREAD_FLAG ON)
+    find_package(Threads REQUIRED)
+    target_link_libraries(${PROJECT_NAME} PUBLIC Threads::Threads)
+ENDIF (UNIX)

--- a/code/common/bits.h
+++ b/code/common/bits.h
@@ -1,6 +1,7 @@
 #pragma once
-#include <type_traits>
 #include <algorithm>
+#include <limits>
+#include <type_traits>
 
 #include "common/types.h"
 
@@ -230,8 +231,16 @@ namespace common::bits
   inline u64 lsb_index(type val)
   {
     ulong index;
-    _BitScanForward64(&index, val);
-
+    #if defined(_MSC_VER)
+      _BitScanForward64(&index, val);
+    #elif defined(__GNUG__) || defined(__clang__)
+      // Watch out for buffer overflow: result is 0
+      // if input is 0.
+      index = static_cast<ulong>(__builtin_ffsll(val));
+      index -= 1;
+    #else
+      static_assert(false, "Not implemented");
+    #endif
     return index;
   }
 
@@ -241,8 +250,13 @@ namespace common::bits
   inline u64 msb_index(type val)
   {
     ulong index;
-    _BitScanReverse64(&index, val);
-
+    #if defined(_MSC_VER)
+      _BitScanReverse64(&index, val);
+    #elif defined(__GNUG__) || defined(__clang__)
+      index = static_cast<ulong>(__builtin_clzll(val));
+    #else
+      static_assert(false, "Not implemented");
+    #endif
     return index;
   }
 

--- a/code/common/clock.cc
+++ b/code/common/clock.cc
@@ -78,7 +78,7 @@ namespace common::time
     #if defined(_WIN32)
       m_start_cycle = current_cycle_count();
     #elif defined(__linux__)
-      this->m_start_time = current_timestamp();
+      m_start_time = current_timestamp();
     #else
       static_assert(false, "Not implemented");
     #endif
@@ -91,7 +91,7 @@ namespace common::time
     #if defined(_WIN32)
       m_end_cycle = current_cycle_count();
     #elif defined(__linux__)
-      this->m_end_time = current_timestamp();
+      m_end_time = current_timestamp();
     #else
       static_assert(false, "Not implemented");
     #endif
@@ -129,7 +129,7 @@ namespace common::time
 
         return cycles_to_seconds(cycles);
     #elif defined(__linux__)
-        return this->m_end_time - this->m_start_time;
+        return m_end_time - m_start_time;
     #else
         static_assert(false, "Not Implemented");
     #endif

--- a/code/common/clock.h
+++ b/code/common/clock.h
@@ -3,6 +3,10 @@
 
 #include "common/types.h"
 
+#ifdef __linux__
+#include <time.h>
+#endif
+
 constexpr float GAME_FPS = 29.97f;
 constexpr float GAME_DT = 1.0f / GAME_FPS;
 constexpr float MENU_FPS = 59.94f;
@@ -11,6 +15,8 @@ constexpr float MENU_DT = 1.0f / MENU_FPS;
 namespace common::time
 {
   using seconds_type = f64;
+
+  #if defined(_WIN32)
   using cycles_type = u64;
 
   // get current cpu counter
@@ -25,6 +31,11 @@ namespace common::time
 
   // convert seconds to cycles
   cycles_type seconds_to_cycles(seconds_type val);
+  #endif
+
+  #if defined(__GNUG__) || defined(__clang__)
+  seconds_type current_timestamp();
+  #endif
 
   // convert from milliseconds
   constexpr seconds_type milliseconds(f64 val)
@@ -62,20 +73,32 @@ namespace common::time
     // reset the timer
     void reset();
 
+    #if defined(_WIN32)
     // number of cycles since start to end
     // or start to now if stop wasn't called
     cycles_type delta_cycles();
+    #endif
 
     // number of seconds since the start to end
     // or start to now if stop wasn't called
     seconds_type delta_seconds();
 
   private:
+    #if defined(_WIN32)
     // the cycle we started at
     cycles_type m_start_cycle{ 0 };
 
     // the cycle we ended at
     cycles_type m_end_cycle{ 0 };
+    #elif defined(__linux__)
+    // the time we started at
+    seconds_type m_start_time{ 0 };
+
+    // the time we ended at
+    seconds_type m_end_time{ 0 };
+    #else
+    static_assert(false, "Not implemented");
+    #endif
 
     // whether the timer is started
     bool m_started{ false };

--- a/code/common/clock.h
+++ b/code/common/clock.h
@@ -15,8 +15,6 @@ constexpr float MENU_DT = 1.0f / MENU_FPS;
 namespace common::time
 {
   using seconds_type = f64;
-
-  #if defined(_WIN32)
   using cycles_type = u64;
 
   // get current cpu counter
@@ -31,11 +29,6 @@ namespace common::time
 
   // convert seconds to cycles
   cycles_type seconds_to_cycles(seconds_type val);
-  #endif
-
-  #if defined(__GNUG__) || defined(__clang__)
-  seconds_type current_timestamp();
-  #endif
 
   // convert from milliseconds
   constexpr seconds_type milliseconds(f64 val)
@@ -73,32 +66,20 @@ namespace common::time
     // reset the timer
     void reset();
 
-    #if defined(_WIN32)
     // number of cycles since start to end
     // or start to now if stop wasn't called
     cycles_type delta_cycles();
-    #endif
 
     // number of seconds since the start to end
     // or start to now if stop wasn't called
     seconds_type delta_seconds();
 
   private:
-    #if defined(_WIN32)
     // the cycle we started at
     cycles_type m_start_cycle{ 0 };
 
     // the cycle we ended at
     cycles_type m_end_cycle{ 0 };
-    #elif defined(__linux__)
-    // the time we started at
-    seconds_type m_start_time{ 0 };
-
-    // the time we ended at
-    seconds_type m_end_time{ 0 };
-    #else
-    static_assert(false, "Not implemented");
-    #endif
 
     // whether the timer is started
     bool m_started{ false };

--- a/code/common/console.cc
+++ b/code/common/console.cc
@@ -1,4 +1,6 @@
+#ifdef _WIN32
 #include <Windows.h>
+#endif
 #include <cstdio>
 #include <iostream>
 
@@ -145,7 +147,9 @@ namespace common::console
 
   void shutdown()
   {
+    #if defined(_WIN32)
     release_console();
+    #endif
   }
 
   void write(std::string_view msg)

--- a/code/common/constants.h
+++ b/code/common/constants.h
@@ -1,5 +1,5 @@
 #pragma once
-#pragma once
+
 #include <limits>
 
 #include "common/types.h"

--- a/code/common/data_stream.cc
+++ b/code/common/data_stream.cc
@@ -22,7 +22,7 @@ namespace common
     usize chunk_size = 0;
 
     std::array<u8, block_size> temp_buffer{ };
-    while (chunk_size = other->read_buffer(temp_buffer.data(), temp_buffer.size()))
+    while ((chunk_size = other->read_buffer(temp_buffer.data(), temp_buffer.size())))
     {
       if (!write_buffer_checked(temp_buffer.data(), chunk_size))
         return false;
@@ -45,7 +45,7 @@ namespace common
     usize chunk_size = 0;
 
     std::array<u8, block_size> temp_buffer{ };
-    while (chunk_size = other->read_buffer(temp_buffer.data(), temp_buffer.size()))
+    while ((chunk_size = other->read_buffer(temp_buffer.data(), temp_buffer.size())))
     {
       if (!write_buffer_checked(temp_buffer.data(), chunk_size))
         return false;

--- a/code/common/debug.cc
+++ b/code/common/debug.cc
@@ -104,10 +104,10 @@ namespace common::debug
     // Extract the backtrace to the requested depth
     // Note that this doesn't give particularly useful results without
     // the -rdynamic linker option
-    void* frame_stack[depth];
-    ::backtrace(frame_stack, depth);
+    std::vector<void*> frame_stack;
+    ::backtrace(frame_stack.data(), depth);
     char** symbols;
-    symbols = ::backtrace_symbols(frame_stack, depth); // Warning: uses malloc() under the hood, requires free()
+    symbols = ::backtrace_symbols(frame_stack.data(), depth); // Warning: uses malloc() under the hood, requires free()
     
     // Convert to std::string
     for (int i=0; i < depth; ++i)

--- a/code/common/debug.cc
+++ b/code/common/debug.cc
@@ -104,7 +104,7 @@ namespace common::debug
     // Extract the backtrace to the requested depth
     // Note that this doesn't give particularly useful results without
     // the -rdynamic linker option
-    std::vector<void*> frame_stack;
+    std::vector<void*> frame_stack{ depth };
     ::backtrace(frame_stack.data(), depth);
     char** symbols;
     symbols = ::backtrace_symbols(frame_stack.data(), depth); // Warning: uses malloc() under the hood, requires free()

--- a/code/common/dynamic_library.cc
+++ b/code/common/dynamic_library.cc
@@ -73,22 +73,22 @@ namespace common
   {
     const auto name_string = std::string{ name };
 
-    library_handle = dlopen(name.c_str(), RTLD_NOW);
+    m_handle = dlopen(name_string.c_str(), RTLD_NOW);
 
     return is_open();
   }
 
   void dynamic_library::impl::close()
   {
-    dlclose(library_handle);
-    library_handle = nullptr;
+    dlclose(m_handle);
+    m_handle = nullptr;
   }
 
   void* dynamic_library::impl::load(std::string_view name)
   {
     const auto name_string = std::string{ name };
 
-    return dlsym(library_handle, name_string.c_str());
+    return dlsym(m_handle, name_string.c_str());
   }
   #else
   #error Not Implemented

--- a/code/common/log.cc
+++ b/code/common/log.cc
@@ -1,4 +1,3 @@
-#pragma once
 #include <limits>
 
 #include "common/log.h"

--- a/code/common/macros.h
+++ b/code/common/macros.h
@@ -1,17 +1,27 @@
 #pragma once
 
-#if defined(_MSC_VER)
 #define WARNING_ID_CONDITIONAL_EXPRESSION_IS_CONSTANT 4127
 #define WARNING_ID_ASSIGNMENT_WITHIN_CONDITIONAL_STATEMENT 4706
 
-#define MSVC_SILENCE_WARNING(id) \
-  __pragma(warning(disable:id))
-
-#define FILE_DISABLE_WARNING(id) MSVC_SILENCE_WARNING(id)
-
-#define ALWAYS_INLINE __forceinline
-#define INLINE inline
+// FILE_DISABLE_WARNING
+#if defined(_MSC_VER)
+  #define MSVC_SILENCE_WARNING(id) \
+    __pragma(warning(disable:id))
+  #define FILE_DISABLE_WARNING(id) MSVC_SILENCE_WARNING(id)
+#elif defined(__GNUG__) || defined(__clang__)
+  #define MSVC_SILENCE_WARNING(id)
+  #define FILE_DISABLE_WARNING(id)
 #endif
+
+// ALWAYS_INLINE
+#if defined(_MSC_VER)
+  #define ALWAYS_INLINE __forceinline
+#elif defined(__GNUG__) || defined(__clang__)
+  #define ALWAYS_INLINE inline __attribute__((__always_inline__))
+#endif
+
+// INLINE
+#define INLINE inline
 
 #define MAYBE_UNUSED [[maybe_unused]]
 #define NO_DISCARD [[nodiscard]]
@@ -19,6 +29,13 @@
 #define FALLTHROUGH [[fallthrough]]
 #define LIKELY [[likely]]
 #define UNLIKELY [[unlikely]]
+
+// ALIGN
+#if defined(_MSC_VER)
+  #define ALIGN(width) __declspec(align(width))
+#elif defined(__GNUG__) || defined(__clang__)
+  #define ALIGN(width) __attribute__((aligned(width)))
+#endif
 
 // Enum class bitwise operators
 #define IMPLEMENT_ENUM_CLASS_BITWISE_OPERATORS(type_)                                                                  \

--- a/code/common/platform.h
+++ b/code/common/platform.h
@@ -5,7 +5,7 @@ namespace common
   enum class platform
   {
     windows,
-    linuxplatform // plain 'linux' is a g++ predefined macro
+    linux_x11
   };
 
   constexpr platform platform_type()
@@ -13,7 +13,7 @@ namespace common
     #if defined(_WIN32)
       return platform::windows;
     #elif defined(__linux__)
-      return platform::linuxplatform;
+      return platform::linux_x11;
     #else
       static_assert(false, "Undefined target platform");
     #endif

--- a/code/common/platform.h
+++ b/code/common/platform.h
@@ -4,11 +4,18 @@ namespace common
 {
   enum class platform
   {
-    windows
+    windows,
+    linuxplatform // plain 'linux' is a g++ predefined macro
   };
 
   constexpr platform platform_type()
   {
-    return platform::windows;
+    #if defined(_WIN32)
+      return platform::windows;
+    #elif defined(__linux__)
+      return platform::linuxplatform;
+    #else
+      static_assert(false, "Undefined target platform");
+    #endif
   }
 }

--- a/code/common/strings.cc
+++ b/code/common/strings.cc
@@ -11,12 +11,12 @@
 
 namespace common::strings
 {
+  #if defined(_WIN32)
   std::optional<std::string> wstring_to_utf8(std::wstring_view wide)
   {
     if (wide.empty())
       return "";
 
-    #if defined(_WIN32)
     auto size = WideCharToMultiByte(CP_UTF8, 0, wide.data(),
       static_cast<int>(wide.size()), nullptr, 0, 0, nullptr);
 
@@ -31,33 +31,6 @@ namespace common::strings
 
     if (size < 1)
       return std::nullopt;
-    #elif defined(__linux__)
-    // Note: There is definitely some kind of template that will unify these
-    // conversions and make the code cleaner to look at/reduce code duplication
-
-    // Make a copy of the input string in case iconv alters it
-    // +1 to make room for a null-terminator we'll add on the end
-    size_t buf_in_size = wide.size() + 1;
-    wchar_t in_buf[buf_in_size];
-    std::wcsncpy(in_buf, wide.data(), wide.size());
-    // Ensure it's null-terminated: wstring_view doesn't guarantee null-termination
-    in_buf[wide.size()] = L'\0';
-
-    // Create pointers to be fed into iconv
-    char* ptr_in = reinterpret_cast<char*>(in_buf); // This is ok, iconv wants a wchar_t* casted to char*
-    size_t buf_out_size = buf_in_size*6; // UTF8 can be up to 6 bytes/symbol, wide is 1 element/symbol by def'n
-    char buf_out[buf_out_size];
-    char* ptr_out = static_cast<char*>(buf_out);
-
-    // wchar_t* to utf8 char*
-    // WCHAR_T should use whatever the system encoding for wchar_t* is
-    // //IGNORE flag will drop anything that can't be utf-8 encoded
-    auto descriptor = iconv_open("UTF-8//IGNORE", "WCHAR_T");
-    iconv(descriptor, &ptr_in, &buf_in_size, &ptr_out, &buf_out_size);
-    iconv_close(descriptor);
-
-    std::string out(buf_out);
-    #endif
 
     return out;
   }
@@ -67,7 +40,6 @@ namespace common::strings
     if (utf8.empty())
       return L"";
 
-    #if defined(_WIN32)
     auto size = MultiByteToWideChar(CP_UTF8, 0, utf8.data(), static_cast<int>(utf8.size()), nullptr, 0);
 
     if (size < 1)
@@ -81,33 +53,10 @@ namespace common::strings
 
     if (size < 1)
       return std::nullopt;
-    #elif defined(__linux__)
-    // Make a copy of the input string in case iconv alters it
-    // +1 to make room for a null-terminator we'll add on the end
-    size_t buf_in_size = utf8.size() + 1;
-    char in_buf[buf_in_size];
-    std::strncpy(in_buf, utf8.data(), utf8.size());
-    // Ensure it's null-terminated: string_view doesn't guarantee null-termination
-    in_buf[utf8.size()] = '\0';
-
-    // Create pointers to be fed into iconv
-    char* ptr_in = static_cast<char*>(in_buf);
-    size_t buf_out_size = buf_in_size; // UTF8 can be a minimum of 1 byte/symbol, wide is 1 element/symbol by def'n
-    wchar_t buf_out[buf_out_size];
-    char* ptr_out = reinterpret_cast<char*>(buf_out); // This is ok, iconv wants a wchar_t* casted to char*
-
-    // utf8 char* to wchar_t*
-    // WCHAR_T should use whatever the system encoding for wchar_t* is
-    // //IGNORE flag will drop anything that can't be WCHAR_T-encoded
-    auto descriptor = iconv_open("WCHAR_T//IGNORE", "UTF-8");
-    iconv(descriptor, &ptr_in, &buf_in_size, &ptr_out, &buf_out_size);
-    iconv_close(descriptor);
-
-    std::wstring out(buf_out);
-    #endif
 
     return out;
   }
+  #endif
 
   std::optional<std::string> sjis_to_utf8(std::string_view sjis)
   {
@@ -156,6 +105,9 @@ namespace common::strings
 
   }
 
+
+
+  #if defined(_WIN32)
   std::string wstring_to_utf8_or_none(std::wstring_view wide)
   {
     const auto utf8 = wstring_to_utf8(wide);
@@ -189,6 +141,7 @@ namespace common::strings
 
     return wide.value();
   }
+  #endif
 
   std::string sjis_to_utf8_or_none(std::string_view sjis)
   {

--- a/code/common/strings.cc
+++ b/code/common/strings.cc
@@ -1,5 +1,9 @@
 #if defined(_WIN32)
-#include <Windows.h>
+  #include <Windows.h>
+#elif defined(__linux__)
+  #include <cstdlib>
+  #include <iconv.h>
+  #include <wchar.h>
 #endif
 
 #include "common/strings.h"
@@ -7,12 +11,12 @@
 
 namespace common::strings
 {
-#if defined(_WIN32)
   std::optional<std::string> wstring_to_utf8(std::wstring_view wide)
   {
     if (wide.empty())
       return "";
 
+    #if defined(_WIN32)
     auto size = WideCharToMultiByte(CP_UTF8, 0, wide.data(),
       static_cast<int>(wide.size()), nullptr, 0, 0, nullptr);
 
@@ -27,6 +31,33 @@ namespace common::strings
 
     if (size < 1)
       return std::nullopt;
+    #elif defined(__linux__)
+    // Note: There is definitely some kind of template that will unify these
+    // conversions and make the code cleaner to look at/reduce code duplication
+
+    // Make a copy of the input string in case iconv alters it
+    // +1 to make room for a null-terminator we'll add on the end
+    size_t buf_in_size = wide.size() + 1;
+    wchar_t in_buf[buf_in_size];
+    std::wcsncpy(in_buf, wide.data(), wide.size());
+    // Ensure it's null-terminated: wstring_view doesn't guarantee null-termination
+    in_buf[wide.size()] = L'\0';
+
+    // Create pointers to be fed into iconv
+    char* ptr_in = reinterpret_cast<char*>(in_buf); // This is ok, iconv wants a wchar_t* casted to char*
+    size_t buf_out_size = buf_in_size*6; // UTF8 can be up to 6 bytes/symbol, wide is 1 element/symbol by def'n
+    char buf_out[buf_out_size];
+    char* ptr_out = static_cast<char*>(buf_out);
+
+    // wchar_t* to utf8 char*
+    // WCHAR_T should use whatever the system encoding for wchar_t* is
+    // //IGNORE flag will drop anything that can't be utf-8 encoded
+    auto descriptor = iconv_open("UTF-8//IGNORE", "WCHAR_T");
+    iconv(descriptor, &ptr_in, &buf_in_size, &ptr_out, &buf_out_size);
+    iconv_close(descriptor);
+
+    std::string out(buf_out);
+    #endif
 
     return out;
   }
@@ -36,6 +67,7 @@ namespace common::strings
     if (utf8.empty())
       return L"";
 
+    #if defined(_WIN32)
     auto size = MultiByteToWideChar(CP_UTF8, 0, utf8.data(), static_cast<int>(utf8.size()), nullptr, 0);
 
     if (size < 1)
@@ -49,17 +81,41 @@ namespace common::strings
 
     if (size < 1)
       return std::nullopt;
+    #elif defined(__linux__)
+    // Make a copy of the input string in case iconv alters it
+    // +1 to make room for a null-terminator we'll add on the end
+    size_t buf_in_size = utf8.size() + 1;
+    char in_buf[buf_in_size];
+    std::strncpy(in_buf, utf8.data(), utf8.size());
+    // Ensure it's null-terminated: string_view doesn't guarantee null-termination
+    in_buf[utf8.size()] = '\0';
+
+    // Create pointers to be fed into iconv
+    char* ptr_in = static_cast<char*>(in_buf);
+    size_t buf_out_size = buf_in_size; // UTF8 can be a minimum of 1 byte/symbol, wide is 1 element/symbol by def'n
+    wchar_t buf_out[buf_out_size];
+    char* ptr_out = reinterpret_cast<char*>(buf_out); // This is ok, iconv wants a wchar_t* casted to char*
+
+    // utf8 char* to wchar_t*
+    // WCHAR_T should use whatever the system encoding for wchar_t* is
+    // //IGNORE flag will drop anything that can't be WCHAR_T-encoded
+    auto descriptor = iconv_open("WCHAR_T//IGNORE", "UTF-8");
+    iconv(descriptor, &ptr_in, &buf_in_size, &ptr_out, &buf_out_size);
+    iconv_close(descriptor);
+
+    std::wstring out(buf_out);
+    #endif
 
     return out;
   }
 
   std::optional<std::string> sjis_to_utf8(std::string_view sjis)
   {
-    static constexpr UINT CP_SJIS = 932;
-
     if (sjis.empty())
       return "";
 
+    #if defined(_WIN32)
+    static constexpr UINT CP_SJIS = 932;
     auto size = MultiByteToWideChar(CP_SJIS, 0, sjis.data(), static_cast<int>(sjis.size()), nullptr, 0);
     if (size < 1)
       return std::nullopt;
@@ -74,6 +130,30 @@ namespace common::strings
       return std::nullopt;
 
     return wstring_to_utf8(out);
+    #elif defined(__linux__)
+    // Make a copy of the input string in case iconv alters it
+    // +1 to make room for a null-terminator we'll add on the end
+    size_t buf_in_size = sjis.size() + 1;
+    char in_buf[buf_in_size];
+    std::strncpy(in_buf, sjis.data(), sjis.size());
+    // Ensure it's null-terminated: string_view doesn't guarantee null-termination
+    in_buf[sjis.size()] = '\0';
+
+    // Create pointers to be fed into iconv
+    char* ptr_in = static_cast<char*>(in_buf);
+    size_t buf_out_size = buf_in_size*6; // UTF8 can be a maximum of 6 bytes/symbol, SHIFT-JIS can be a minimum of 1 byte/symbol
+    char buf_out[buf_out_size];
+    char* ptr_out = static_cast<char*>(buf_out);
+
+    // shift-jis char* to utf-8 char*
+    // //IGNORE flag will drop anything that can't be utf8-encoded
+    auto descriptor = iconv_open("UTF-8//IGNORE", "SHIFT-JIS");
+    iconv(descriptor, &ptr_in, &buf_in_size, &ptr_out, &buf_out_size);
+    iconv_close(descriptor);
+
+    return std::string(buf_out);
+    #endif
+
   }
 
   std::string wstring_to_utf8_or_none(std::wstring_view wide)
@@ -126,5 +206,4 @@ namespace common::strings
 
     return utf8.value();
   }
-#endif
 }

--- a/code/common/strings.h
+++ b/code/common/strings.h
@@ -11,7 +11,7 @@
 #include "common/types.h"
 #include "common/macros.h"
 
-FILE_DISABLE_WARNING(WARNING_ID_CONDITIONAL_EXPRESSION_IS_CONSTANT);
+FILE_DISABLE_WARNING(WARNING_ID_CONDITIONAL_EXPRESSION_IS_CONSTANT)
 
 namespace common::strings
 {

--- a/code/common/strings.h
+++ b/code/common/strings.h
@@ -21,15 +21,19 @@ namespace common::strings
     std::same_as<type, char> || std::same_as<type, wchar_t>;
   };
 
+  #if defined(_WIN32)
   std::optional<std::string>  wstring_to_utf8(std::wstring_view wide);
   std::optional<std::wstring> utf8_to_wstring(std::string_view utf8);
+  #endif
   std::optional<std::string> sjis_to_utf8(std::string_view sjis);
 
+  #if defined(_WIN32)
   std::string wstring_to_utf8_or_none(std::wstring_view wide);
   std::string wstring_to_utf8_or_panic(std::wstring_view wide);
 
   std::wstring utf8_to_wstring_or_none(std::string_view utf8);
   std::wstring utf8_to_wstring_or_panic(std::string_view utf8);
+  #endif
 
   std::string sjis_to_utf8_or_none(std::string_view sjis);
   std::string sjis_to_utf8_or_panic(std::string_view sjis);

--- a/code/common/strings.h
+++ b/code/common/strings.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <optional>
 #include <concepts>
 #include <string>
@@ -20,7 +21,6 @@ namespace common::strings
     std::same_as<type, char> || std::same_as<type, wchar_t>;
   };
 
-#if defined(_WIN32)
   std::optional<std::string>  wstring_to_utf8(std::wstring_view wide);
   std::optional<std::wstring> utf8_to_wstring(std::string_view utf8);
   std::optional<std::string> sjis_to_utf8(std::string_view sjis);
@@ -33,7 +33,6 @@ namespace common::strings
 
   std::string sjis_to_utf8_or_none(std::string_view sjis);
   std::string sjis_to_utf8_or_panic(std::string_view sjis);
-#endif // _WIN32
 
   // format a string
   // note: fmtstr must be constexpr

--- a/code/common/synchro.cc
+++ b/code/common/synchro.cc
@@ -1,33 +1,64 @@
-#include <Windows.h>
+#if defined(_WIN32)
+    #include <Windows.h>
+#elif defined(__linux__)
+    #include <pthread.h>
+    #include <time.h>
+#else
+  static_assert(false, "synchro.cc not defined for this operating system");
+#endif
 
+#include "common/debug.h"
 #include "common/dynamic_library.h"
 #include "common/strings.h"
 #include "common/synchro.h"
 
 namespace common::synchro
 {
+  #if defined(_WIN32)
   static dynamic_library s_kernel32_lib{ "kernel32.dll" };
+  #endif
 
   sint current_thread_id()
   {
-    return GetCurrentThreadId();
+    #if defined(_WIN32)
+        return GetCurrentThreadId();
+    #elif defined(__linux__)
+        return static_cast<sint>(pthread_self()); // Return type might need to be OS-dependent
+    #else
+        static_assert(false, "Not implemented");
+    #endif
   }
 
   void set_current_thread_name(std::string_view name)
   {
-    using pfn_set_thread_description = decltype(&SetThreadDescription);
+    #if defined(_WIN32)
+      using pfn_set_thread_description = decltype(&SetThreadDescription);
 
-    static auto p_set_thread_description = s_kernel32_lib.load_pfn_type<pfn_set_thread_description>("SetThreadDescription");
-    if (!p_set_thread_description)
-      return;
+      static auto p_set_thread_description = s_kernel32_lib.load_pfn_type<pfn_set_thread_description>("SetThreadDescription");
+      if (!p_set_thread_description)
+        return;
 
-    auto wname = strings::utf8_to_wstring_or_panic(name);
+      auto wname = strings::utf8_to_wstring_or_panic(name);
 
-    p_set_thread_description(GetCurrentThread(), wname.c_str());
+      p_set_thread_description(GetCurrentThread(), wname.c_str());
+    #elif defined(__linux__)
+      pthread_setname_np(pthread_self(), name.data());
+    #else
+      static_assert(false, "Not implemented");
+    #endif
   }
 
   void sleep_current_thread(uint ms)
   {
-    Sleep(ms);
+    #if defined(_WIN32)
+      Sleep(ms);
+    #elif defined(__linux__)
+      timespec ts;
+      ts.tv_sec  = ms / 1000;
+      ts.tv_nsec = (ms % 1000) * 1000000;
+      nanosleep(&ts, NULL);
+    #else
+      static_assert(false, "Not implemented");
+    #endif
   }
 }

--- a/code/common/synchro.h
+++ b/code/common/synchro.h
@@ -7,6 +7,7 @@
 namespace common::synchro
 {
   // get the id of the current thread
+  // P: The return type might need to be OS-dependent
   sint current_thread_id();
 
   // set the name of the current thread

--- a/code/common/window_handle.h
+++ b/code/common/window_handle.h
@@ -1,10 +1,9 @@
 #pragma once
 #if defined(_WIN32)
-    #include <Windows.h>
+  #include <Windows.h>
 #elif defined(__linux__)
-
 #else
-    static_assert(false, "Not implemented");
+  static_assert(false, "Not implemented");
 #endif
 
 #include "common/platform.h"
@@ -23,10 +22,10 @@ namespace common
   };
   #elif defined(__linux__)
   template<>
-  struct window_handle_t<platform::linuxplatform>
+  struct window_handle_t<platform::linux_x11>
   {
-    // Don't know the type to go in here yet
-    //HWND window_handle{ nullptr };
+    void* connection; // Display from e.g. XOpenDisplay(NULL)
+    void* handle;     // Window from e.g. XCreateSimpleWindow(...)
   };
   #endif
 

--- a/code/common/window_handle.h
+++ b/code/common/window_handle.h
@@ -1,17 +1,34 @@
 #pragma once
-#include <Windows.h>
+#if defined(_WIN32)
+    #include <Windows.h>
+#elif defined(__linux__)
+
+#else
+    static_assert(false, "Not implemented");
+#endif
+
 #include "common/platform.h"
+
 
 namespace common
 {
   template<enum platform>
   struct window_handle_t;
 
+  #if defined(_WIN32)
   template<>
   struct window_handle_t<platform::windows>
   {
     HWND window_handle{ nullptr };
   };
+  #elif defined(__linux__)
+  template<>
+  struct window_handle_t<platform::linuxplatform>
+  {
+    // Don't know the type to go in here yet
+    //HWND window_handle{ nullptr };
+  };
+  #endif
 
   using native_window_handle_type = window_handle_t<platform_type()>;
 }


### PR DESCRIPTION
Linux port of /code/common.
Also contains the following fixes:
- An incorrect member name reference in `common/dynamic_library.cc`
- Removal of a `#pragma once` in `common/log.cc`
- Brackets around avariable updated in a loop in `common/data_stream.cc` that caused GCC to complain

One thing attention should be drawn to is the implementation of `/code/common/clock.h`/`.cc`. These currently involve `#ifdef`'ing out any code that operates in terms of cycles and replaces it solely with an interface that deals in floating-point time intervals for the Linux interface.
Now that I'm wiser, this could be replaced with cycles-oriented stand-ins.