### PR TITLE
Feature/linux exe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,3 @@ add_subdirectory("external")
 
 # add the main code directory
 add_subdirectory("code")
-
-# Notes
-# sudo apt install g++-10 : C++20 headers
-# sudo ./cmake-3.25.1-linux-x86_64.sh --skip-license --exclude-subdir --prefix=/usr : install cmake from release script

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_STANDARD 23)
 add_subdirectory("version")
 add_subdirectory("common")
 add_subdirectory("data")
-#add_subdirectory("script")
+add_subdirectory("script")
 add_subdirectory("graph")
 add_subdirectory("engine")
 add_subdirectory("host")
@@ -16,27 +16,24 @@ add_subdirectory("host")
 ##############################
 # BUILD OPENCLOUD EXECUTABLE #
 ##############################
-# Enable and IF-guard when host is ported
-#SET(
-#    SOURCES
-#    "host/linuxmain.cc"
-#)
+PROJECT(OpenCloudExe)
+add_executable(${PROJECT_NAME})
 
-#PROJECT(OpenCloudExe)
-#add_executable(${PROJECT_NAME} ${SOURCES})
+IF (WIN32)
+    SET(mainfunc host/winmain.cc)
+ELSEIF(APPLE)
+    message(FATAL_ERROR "Apple builds currently unsupported")
+ELSEIF(UNIX AND NOT APPLE)
+    SET(mainfunc host/linuxmain.cc)
+ELSE()
+    message(FATAL_ERROR "Unrecognised operating system")
+ENDIF()
 
-#find_package(X11 REQUIRED)
-#target_link_libraries(${PROJECT_NAME} PRIVATE ${X11_LIBRARIES})
-#target_include_directories(${PROJECT_NAME} PRIVATE ${X11_INCLUDE_DIR})
 
-#find_package(OpenGL REQUIRED)
-#target_link_libraries(${PROJECT_NAME} PRIVATE OpenGL::OpenGL OpenGL::GLX OpenGL::GLU)
-#target_include_directories(${PROJECT_NAME} PRIVATE ${OPENGL_INCLUDE_DIR})
+target_sources(
+    ${PROJECT_NAME}
+    PRIVATE
+    ${mainfunc}
+)
 
-# Puts the names of non-static functions into the link tables so the generated backtrace
-# is actually readable
-#IF (CMAKE_BUILD_TYPE MATCHES Debug)
-#    IF (("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang") OR ("${CMAKE_CXX_COMPILER_ID}" #STREQUAL "GNU"))
-#        target_link_options(${PROJECT_NAME} PRIVATE "-rdynamic")
-#    ENDIF()
-#ENDIF()
+target_link_libraries(${PROJECT_NAME} PRIVATE ProjectConfiguration OpenCloudCommon OpenCloudEngine OpenCloudHost OpenCloudScript OpenCloudGraph)

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -17,13 +17,14 @@ add_subdirectory("host")
 # BUILD OPENCLOUD EXECUTABLE #
 ##############################
 PROJECT(OpenCloudExe)
-add_executable(${PROJECT_NAME})
 
 IF (WIN32)
+    add_executable(${PROJECT_NAME} WIN32)
     SET(mainfunc host/winmain.cc)
 ELSEIF(APPLE)
     message(FATAL_ERROR "Apple builds currently unsupported")
 ELSEIF(UNIX AND NOT APPLE)
+    add_executable(${PROJECT_NAME})
     SET(mainfunc host/linuxmain.cc)
 ELSE()
     message(FATAL_ERROR "Unrecognised operating system")

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -26,9 +26,9 @@ ELSEIF(APPLE)
 ELSEIF(UNIX AND NOT APPLE)
     add_executable(${PROJECT_NAME})
     SET(mainfunc host/linuxmain.cc)
-ELSE()
+ELSE(WIN32)
     message(FATAL_ERROR "Unrecognised operating system")
-ENDIF()
+ENDIF(WIN32)
 
 
 target_sources(

--- a/code/common/CMakeLists.txt
+++ b/code/common/CMakeLists.txt
@@ -41,6 +41,9 @@ target_sources(
 )
 
 target_link_libraries(${PROJECT_NAME} PRIVATE ProjectConfiguration PUBLIC fmt::fmt simdjson)
+if(WIN32) 
+    target_link_libraries(${PROJECT_NAME} PUBLIC Dbghelp) 
+endif (WIN32)
 
 # Include pthread for Linux
 IF (UNIX)

--- a/code/engine/CMakeLists.txt
+++ b/code/engine/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 
-project(OpenCloudDC2)
+project(OpenCloudEngine)
 add_library(${PROJECT_NAME} STATIC)
 
 target_sources(

--- a/code/host/linuxmain.cc
+++ b/code/host/linuxmain.cc
@@ -9,7 +9,7 @@
 
 #include "host/host_interface_x11.h"
 
-#include "dc2/mainloop.h"
+#include "engine/mainloop.h"
 
 set_log_channel("main");
 

--- a/code/host/linuxmain.cc
+++ b/code/host/linuxmain.cc
@@ -8,6 +8,7 @@
 #include "common/scoped_function.h"
 
 #include "host/host_interface_x11.h"
+#undef None
 
 #include "engine/mainloop.h"
 

--- a/code/script/CMakeLists.txt
+++ b/code/script/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(OpenCloudScript)
+add_library(${PROJECT_NAME} STATIC)
+
+target_sources(
+    ${PROJECT_NAME}
+    PRIVATE
+    "analyzer.cc"
+    
+    "analyzer.h"
+    "bytecode.h"
+    "file.h"
+    "stack.h"
+)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE ProjectConfiguration)
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpermissive")
+endif()


### PR DESCRIPTION
Finalise basic executable compilation for Linux. Note that the executable will segfault unless a gamepad can be detected due to alternate behaviour not yet being implemented in `host`.

Changelist:
- Add a CMake subproject for `code/script`
- Rename CMake subproject `OpenCloudDC2` to `OpenCloudEngine`
- Small edit to `host/linuxmain.cc` to prevent X11 causing compile errors in the rest of the codebase
- Build an executable for the project in the `OpenCloudExe`  subproject, which pulls together the previously-ported subprojects.